### PR TITLE
Add skip for some pre-commit in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,8 @@ repos:
         entry: env CUSTOM_COMPILE_COMMAND="make dev-requirements.txt" pip-compile
         args: [dev-requirements.in]
         files: ^dev-requirements\.(in|txt)$
+
+ci:
+  skip:
+    - pyright
+    - pip-compile


### PR DESCRIPTION
pre-commit.ci doesn't allow external network connections, so downloading
node for pyright and checking PyPI for pip-compile doesn't work.
